### PR TITLE
Fix sendEvent fired before React was fully set up

### DIFF
--- a/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
+++ b/android/src/main/java/com/geektime/rnonesignalandroid/RNOneSignal.java
@@ -100,6 +100,10 @@ public class RNOneSignal extends ReactContextBaseJavaModule implements Lifecycle
    }
 
    private void sendEvent(String eventName, Object params) {
+      if(!mReactContext.hasActiveCatalystInstance()) {
+         return;
+      }
+      
       mReactContext
               .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
               .emit(eventName, params);


### PR DESCRIPTION
**Bug**  
The application crashed after received notification when application is still starting up (the React instance had not been fully set up)

**Resolved By**  
Add react instance checker before emit event